### PR TITLE
Fix horizontal overflow bug on profile page

### DIFF
--- a/src/shiftings/accounts/templates/accounts/user_detail.html
+++ b/src/shiftings/accounts/templates/accounts/user_detail.html
@@ -84,8 +84,8 @@
           </button>
         </div>
       </div>
-      <div id="collapseOrgBody" class="collapse show card-body pt-0">
-        <div class="d-flex gap-2 overflow-scroll">
+      <div id="collapseOrgBody" class="collapse show" style="flex-wrap: wrap">
+        <div class="d-flex gap-2">
           {% for organization in user.organizations.all %}
             <a class="link" href="{% url "organization" organization.pk %}">
               <div class="bg-dark border border-2 my-2 center-items justify-content-start flex-row card-link">

--- a/src/shiftings/accounts/templates/accounts/user_detail.html
+++ b/src/shiftings/accounts/templates/accounts/user_detail.html
@@ -74,7 +74,7 @@
     </div>
     <div class="card bg-dark">
       <div class="card-header center-items justify-content-between">
-        <h5>{% trans "Organizations" %}</h5>
+        <h4>{% trans "Organizations" %}</h4>
         <div>
           <button class="d-block d-lg-none btn btn-secondary" data-bs-toggle="collapse"
                   data-bs-target="#collapseOrgBody"
@@ -84,8 +84,8 @@
           </button>
         </div>
       </div>
-      <div id="collapseOrgBody" class="collapse show">
-        <div class="d-flex gap-2 py-1 px-2">
+      <div id="collapseOrgBody" class="collapse show card-body pt-0">
+        <div class="d-flex gap-2 overflow-scroll">
           {% for organization in user.organizations.all %}
             <a class="link" href="{% url "organization" organization.pk %}">
               <div class="bg-dark border border-2 my-2 center-items justify-content-start flex-row card-link">

--- a/src/shiftings/accounts/templates/accounts/user_detail.html
+++ b/src/shiftings/accounts/templates/accounts/user_detail.html
@@ -84,8 +84,8 @@
           </button>
         </div>
       </div>
-      <div id="collapseOrgBody" class="collapse show" style="flex-wrap: wrap">
-        <div class="d-flex gap-2">
+      <div id="collapseOrgBody" class="collapse show">
+        <div class="d-flex gap-2 py-1 px-2 flex-wrap">
           {% for organization in user.organizations.all %}
             <a class="link" href="{% url "organization" organization.pk %}">
               <div class="bg-dark border border-2 my-2 center-items justify-content-start flex-row card-link">


### PR DESCRIPTION
The problem stands as follows:

<img width="716" alt="Bildschirm­foto 2024-07-07 um 02 41 18" src="https://github.com/HaDiNet/shiftings/assets/88612157/2350c337-0108-487f-ba2c-b0e9503bc612">

The same view now looks like this:

<img width="619" alt="Bildschirm­foto 2024-07-07 um 02 39 47" src="https://github.com/HaDiNet/shiftings/assets/88612157/336c4172-3569-46ec-94ca-f448da2f4b9e">

This PR tries to fix this visual bug by making the content scroll horizontally and neatly hiding any overflowing organizations. This doesn't break the collapse-feature.

GaLiGrü