### PR TITLE
Show shifts a user participates in user profile

### DIFF
--- a/src/shiftings/accounts/views/user.py
+++ b/src/shiftings/accounts/views/user.py
@@ -45,7 +45,8 @@ class UserProfileView(BaseLoginMixin, ShiftFilterMixin, DetailView):
         else:
             shifts = Shift.objects.filter(Q(start__date__gte=today) &
                                           (Q(event__in=self.object.events) |
-                                           Q(organization__in=self.object.organizations)))
+                                           Q(organization__in=self.object.organizations) |
+                                           Q(participants__user=self.object)))
         context['shifts'] = get_pagination_context(self.request, shifts.filter(self.get_filters()), 5, 'shifts')
         return context
 


### PR DESCRIPTION
If a user is added to a shift in a organisation he is not part of it is not shown in the user's overview. This change expands the appropriate filter.

Fixes #35.