### PR TITLE
Add local Keycloak OIDC dev environment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@schliz @hd1ex @mfbehrens @pablo-schmeiser
+* @schliz @hd1ex @mfbehrens @pablo-schmeiser

--- a/README.md
+++ b/README.md
@@ -68,9 +68,27 @@ python src/manage.py runserver
 
 After that you can access your local shiftings instance at <http://127.0.0.1:8000/>.
 
+#### OIDC login with Keycloak (recommended)
+
+For development with OIDC authentication (matching the production setup), a local Keycloak instance is provided via Docker Compose:
+
+```shell
+docker compose -f docker-compose.dev.yml up -d
+```
+
+Then copy the dev settings template (if you haven't already):
+
+```shell
+cp src/shiftings/local_settings.dev.py src/shiftings/local_settings.py
+```
+
+Alternatively, `setup_dev.sh` does both the settings copy and database setup in one step.
+
+The Keycloak admin console is available at <http://localhost:8080> (admin/admin). All test users (see below) can log in via SSO with the password `password`. The login page will show both "Login with local Account" and "Login via Single Sign-On" options.
+
 #### User fixtures
 
-In development mode you can switch between the pre-defined user fixtures with a button in the context menu at the top right of the web page or you can login using the lower case name as username and password (`bob`, `perry` etc.). **Bob** is a superuser and has access to the [Django admin page](http://127.0.0.1:8000/admin/) and **Perry** is a staff member. The other users have [different access to the first example organization](http://127.0.0.1:8000/organizations/1/admin/) provided by the fixture. Follow the provided links for more info.
+In development mode you can switch between the pre-defined user fixtures with a button in the context menu at the top right of the web page or you can login using the lower case name as username and password (`bob`, `perry` etc.) for local login, or via SSO with the password `password`. **Bob** is a superuser and has access to the [Django admin page](http://127.0.0.1:8000/admin/) and **Perry** is a staff member. The other users have [different access to the first example organization](http://127.0.0.1:8000/organizations/1/admin/) provided by the fixture. Follow the provided links for more info.
 
 #### Upgrade Django version
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,11 @@
+services:
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.2
+    command: start-dev --import-realm
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./keycloak/realm-export.json:/opt/keycloak/data/import/realm-export.json:ro

--- a/keycloak/realm-export.json
+++ b/keycloak/realm-export.json
@@ -1,0 +1,458 @@
+{
+  "id": "shiftings",
+  "realm": "shiftings",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": false,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "defaultSignatureAlgorithm": "RS256",
+  "offlineSessionMaxLifespan": 5184000,
+  "offlineSessionMaxLifespanEnabled": true,
+  "accessTokenLifespan": 300,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "roles": {
+    "realm": [
+      {
+        "name": "default-roles-shiftings",
+        "description": "${role_default-roles}",
+        "composite": true,
+        "composites": {
+          "realm": [
+            "offline_access"
+          ],
+          "client": {
+            "account": [
+              "view-profile",
+              "manage-account"
+            ]
+          }
+        }
+      },
+      {
+        "name": "offline_access",
+        "description": "${role_offline-access}"
+      }
+    ]
+  },
+  "groups": [
+    {
+      "name": "admin",
+      "path": "/admin"
+    },
+    {
+      "name": "K1 Bar",
+      "path": "/K1 Bar"
+    },
+    {
+      "name": "Music",
+      "path": "/Music"
+    }
+  ],
+  "defaultRole": {
+    "name": "default-roles-shiftings",
+    "description": "${role_default-roles}",
+    "composite": true
+  },
+  "clients": [
+    {
+      "clientId": "shiftings",
+      "name": "Shiftings",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "shiftings-dev-secret",
+      "redirectUris": [
+        "http://127.0.0.1:8000/*",
+        "http://localhost:8000/*"
+      ],
+      "webOrigins": [
+        "http://127.0.0.1:8000",
+        "http://localhost:8000"
+      ],
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "fullScopeAllowed": true,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "email",
+        "basic"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ],
+      "protocolMappers": [
+        {
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-group-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "full.path": "false",
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups"
+          }
+        }
+      ]
+    }
+  ],
+  "clientScopes": [
+    {
+      "name": "offline_access",
+      "description": "OpenID Connect built-in scope: offline_access",
+      "protocol": "openid-connect",
+      "attributes": {
+        "consent.screen.text": "${offlineAccessScopeConsentText}",
+        "display.on.consent.screen": "true"
+      }
+    },
+    {
+      "name": "profile",
+      "description": "OpenID Connect built-in scope: profile",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${profileScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "name": "email",
+      "description": "OpenID Connect built-in scope: email",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${emailScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "name": "roles",
+      "description": "OpenID Connect scope for add user roles to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${rolesScopeConsentText}"
+      }
+    },
+    {
+      "name": "web-origins",
+      "description": "OpenID Connect scope for add allowed web origins to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      }
+    },
+    {
+      "name": "acr",
+      "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      }
+    },
+    {
+      "name": "basic",
+      "description": "OpenID Connect scope for add all basic claims to the token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      }
+    }
+  ],
+  "users": [
+    {
+      "username": "bob",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Robert",
+      "lastName": "Kelso",
+      "email": "robert.kelso@sacred-heart.org",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "default-roles-shiftings",
+        "offline_access"
+      ],
+      "groups": [
+        "admin",
+        "K1 Bar"
+      ]
+    },
+    {
+      "username": "perry",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Percival",
+      "lastName": "Cox",
+      "email": "percival.cov@sacred-heart.org",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password",
+          "temporary": false
+        }
+      ],
+      "groups": [
+        "K1 Bar"
+      ],
+      "realmRoles": [
+        "default-roles-shiftings",
+        "offline_access"
+      ]
+    },
+    {
+      "username": "elliot",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Elliot",
+      "lastName": "Reid",
+      "email": "elliot.reid@sacred-heart.org",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password",
+          "temporary": false
+        }
+      ],
+      "groups": [
+        "K1 Bar"
+      ],
+      "realmRoles": [
+        "default-roles-shiftings",
+        "offline_access"
+      ]
+    },
+    {
+      "username": "jd",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "John",
+      "lastName": "Dorian",
+      "email": "john.dorian@sacred-heart.org",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password",
+          "temporary": false
+        }
+      ],
+      "groups": [
+        "K1 Bar"
+      ],
+      "realmRoles": [
+        "default-roles-shiftings",
+        "offline_access"
+      ]
+    },
+    {
+      "username": "turk",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christopher",
+      "lastName": "Turk",
+      "email": "christopher.turk@sacred-heart.org",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password",
+          "temporary": false
+        }
+      ],
+      "groups": [
+        "K1 Bar"
+      ],
+      "realmRoles": [
+        "default-roles-shiftings",
+        "offline_access"
+      ]
+    },
+    {
+      "username": "carla",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Carla",
+      "lastName": "Espinosa",
+      "email": "carla.espinosa@sacred-heart.org",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password",
+          "temporary": false
+        }
+      ],
+      "groups": [
+        "K1 Bar"
+      ],
+      "realmRoles": [
+        "default-roles-shiftings",
+        "offline_access"
+      ]
+    },
+    {
+      "username": "janitor",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Glen",
+      "lastName": "Matthews",
+      "email": "glen.matthews@sacred-heart.org",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password",
+          "temporary": false
+        }
+      ],
+      "groups": [
+        "K1 Bar"
+      ],
+      "realmRoles": [
+        "default-roles-shiftings",
+        "offline_access"
+      ]
+    },
+    {
+      "username": "jordan",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Jordan",
+      "lastName": "Sullivan",
+      "email": "jordan.sullivan@sacred-heart.org",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password",
+          "temporary": false
+        }
+      ],
+      "groups": [],
+      "realmRoles": [
+        "default-roles-shiftings",
+        "offline_access"
+      ]
+    },
+    {
+      "username": "ted",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Ted",
+      "lastName": "Buckland",
+      "email": "ted.buckland@sacred-heart.org",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password",
+          "temporary": false
+        }
+      ],
+      "groups": [],
+      "realmRoles": [
+        "default-roles-shiftings",
+        "offline_access"
+      ]
+    },
+    {
+      "username": "gooch",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Stephanie",
+      "lastName": "Gooch",
+      "email": "kate.micucci@garfunkelandoates.com",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password",
+          "temporary": false
+        }
+      ],
+      "groups": [
+        "Music"
+      ],
+      "realmRoles": [
+        "default-roles-shiftings",
+        "offline_access"
+      ]
+    }
+  ]
+}

--- a/setup_dev.sh
+++ b/setup_dev.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Setup dev environment with Keycloak OIDC support.
+# Prerequisites: Docker (for Keycloak), Python venv at .venv (via uv)
+
+set -e
+
+SETTINGS_FILE="src/shiftings/local_settings.py"
+DEV_SETTINGS="src/shiftings/local_settings.dev.py"
+
+if [ ! -f "$SETTINGS_FILE" ]; then
+    cp "$DEV_SETTINGS" "$SETTINGS_FILE"
+    echo "Created local_settings.py from dev template (OIDC enabled)"
+else
+    echo "local_settings.py already exists, skipping copy"
+fi
+
+./setup_db.sh
+
+echo ""
+echo "=========================================="
+echo "  Dev setup complete!"
+echo "=========================================="
+echo ""
+echo "Start Keycloak:  docker compose -f docker-compose.dev.yml up -d"
+echo "Start Django:    .venv/bin/python src/manage.py runserver"
+echo ""
+echo "Keycloak admin:  http://localhost:8080       (admin / admin)"
+echo "Shiftings:       http://127.0.0.1:8000       (SSO + local login)"
+echo ""
+echo "Keycloak users all have password: password"
+echo ""

--- a/src/shiftings/local_settings.dev.py
+++ b/src/shiftings/local_settings.dev.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# Development settings for local Keycloak OIDC login.
+# Copy this file to local_settings.py to enable OIDC alongside local auth.
+# Requires Keycloak running via: docker compose -f docker-compose.dev.yml up
+
+OAUTH_ENABLED = True
+LOCAL_LOGIN_ENABLED = True  # keep both login methods available
+
+AUTHLIB_OAUTH_CLIENTS = {
+    'shiftings': {
+        'client_id': 'shiftings',
+        'client_secret': 'shiftings-dev-secret',
+    }
+}
+
+OPENID_CONF_URL = 'http://localhost:8080/realms/shiftings/.well-known/openid-configuration'
+
+# Keycloak standard OIDC claim names
+OAUTH_USERNAME_CLAIM = 'preferred_username'
+OAUTH_FIRST_NAME_CLAIM = 'given_name'
+OAUTH_LAST_NAME_CLAIM = 'family_name'
+OAUTH_GROUP_CLAIM = 'groups'
+OAUTH_EMAIL_CLAIM = 'email'
+OAUTH_CLIENT_SCOPES = 'openid profile email'
+OAUTH_ADMIN_GROUP = 'admin'
+OAUTH_GROUP_IGNORE_REGEX = r'^$'  # don't ignore any groups in dev


### PR DESCRIPTION
## Summary

- Add a Docker Compose-based Keycloak instance for local OIDC development, mirroring the production SSO login flow
- Pre-configured realm with all fixture users (bob, perry, elliot, etc.), groups (admin, K1 Bar, Music), and an OIDC client
- Ready-to-copy local_settings.dev.py and setup_dev.sh convenience script for quick onboarding
- Keycloak client includes offline_access as an optional scope, preparing for future calendar feed token work

## Motivation

Development currently uses local Django users, which means the OIDC login flow is never exercised locally. This makes it difficult to develop and test SSO-dependent features like calendar feed authentication with offline tokens.

## Usage

    docker compose -f docker-compose.dev.yml up -d
    ./setup_dev.sh
    .venv/bin/python src/manage.py runserver

All Keycloak users have the password password. Both local and SSO login are available side-by-side.

## Manual verifications run

- docker compose -f docker-compose.dev.yml up starts Keycloak and imports the realm
- Login page shows both "Login with local Account" and "Login via Single Sign-On"
- SSO login as bob/password redirects through Keycloak and back to Django with correct user attributes
- Groups (K1 Bar, admin) are synced as Django auth groups
- bob gets is_superuser via the admin group
- Local login still works (e.g. elliot/elliot)